### PR TITLE
Remove Debug log

### DIFF
--- a/Sources/SwiftLeakCheck/FunctionSignature.swift
+++ b/Sources/SwiftLeakCheck/FunctionSignature.swift
@@ -52,8 +52,6 @@ public struct FunctionSignature {
       return .nameMismatch
     }
     
-    print("Debug: \(functionCallExpr)")
-    
     return match((ArgumentListWrapper(functionCallExpr.argumentList), functionCallExpr.trailingClosure))
   }
   


### PR DESCRIPTION
Run SwiftLeakCheck (version 1.3.0) for the target path, the below results are displayed.

```
Scan file:///path/to/swift/file
Finished in 0.011775970458984375 seconds
  `self` is strongly captured at (line: 290, column: 13)"),
  from a potentially escaped closure.
Scan file:///path/to/swift/file
Debug:

   ... some codes ...

```

It is no need to display for result.
